### PR TITLE
update terraform_default.tf azurerm provider info

### DIFF
--- a/bentoctl_container_instances/templates/terraform_default.tf
+++ b/bentoctl_container_instances/templates/terraform_default.tf
@@ -9,6 +9,7 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
+  features {}
 }
 
 ################################################################################
@@ -89,9 +90,10 @@ resource "azurerm_container_group" "bentoml" {
     password = data.azurerm_container_registry.registry.admin_password
   }
 
-  environment_variables {
-    BENTOMLPORT = "3000"
-  }
+  #environment_variables {
+  #  BENTOMLPORT = "3000"
+  #}
+  
   container {
     name   = "bentoml"
     image  = var.image_tag


### PR DESCRIPTION
update the provider azurerm terraform features into the terraform_default.tf and comment the environment variable due to the block is not supported by azurerm terraform documentation

for more info, please related to terraform documentation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block